### PR TITLE
feat: add HTTP/SSE transport support with backward compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,6 +176,7 @@ project_resources/
 ._*.py
 ._.repo_ignore
 .repo_ignore
+.claude/
 
 # Ruff
 .ruff_cache/

--- a/src/airflow_mcp_server/server_safe.py
+++ b/src/airflow_mcp_server/server_safe.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Literal
 
 import httpx
 from fastmcp import FastMCP
@@ -12,13 +13,21 @@ from airflow_mcp_server.resources import add_airflow_resources
 logger = logging.getLogger(__name__)
 
 
-async def serve(config: AirflowConfig, static_tools: bool = False) -> None:
+async def serve(config: AirflowConfig, static_tools: bool = False, transport: Literal["stdio", "streamable-http", "sse"] = "stdio", **transport_kwargs) -> None:
     """Start MCP server in safe mode (read-only operations).
 
     Args:
         config: Configuration object with auth and URL settings
         static_tools: If True, use static tools instead of hierarchical discovery
+        transport: Transport type ("stdio", "streamable-http", "sse")
+        **transport_kwargs: Additional transport configuration (port, host, etc.)
     """
+
+    if not config.base_url:
+        raise ValueError("base_url is required")
+    if not config.auth_token:
+        raise ValueError("auth_token is required")
+
     client = httpx.AsyncClient(base_url=config.base_url, headers={"Authorization": f"Bearer {config.auth_token}"}, timeout=30.0)
 
     try:
@@ -47,7 +56,10 @@ async def serve(config: AirflowConfig, static_tools: bool = False) -> None:
     add_airflow_prompts(mcp, mode="safe")
 
     try:
-        await mcp.run_async()
+        if transport in ["streamable-http", "sse"]:
+            await mcp.run_async(transport=transport, **transport_kwargs)
+        else:
+            await mcp.run_async()
     except Exception as e:
         logger.error("Server error: %s", e)
         await client.aclose()

--- a/src/airflow_mcp_server/server_unsafe.py
+++ b/src/airflow_mcp_server/server_unsafe.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Literal
 
 import httpx
 from fastmcp import FastMCP
@@ -12,13 +13,20 @@ from airflow_mcp_server.resources import add_airflow_resources
 logger = logging.getLogger(__name__)
 
 
-async def serve(config: AirflowConfig, static_tools: bool = False) -> None:
+async def serve(config: AirflowConfig, static_tools: bool = False, transport: Literal["stdio", "streamable-http", "sse"] = "stdio", **transport_kwargs) -> None:
     """Start MCP server in unsafe mode (all operations).
 
     Args:
         config: Configuration object with auth and URL settings
         static_tools: If True, use static tools instead of hierarchical discovery
+        transport: Transport type ("stdio", "streamable-http", "sse")
+        **transport_kwargs: Additional transport configuration (port, host, etc.)
     """
+    if not config.base_url:
+        raise ValueError("base_url is required")
+    if not config.auth_token:
+        raise ValueError("auth_token is required")
+
     client = httpx.AsyncClient(base_url=config.base_url, headers={"Authorization": f"Bearer {config.auth_token}"}, timeout=30.0)
 
     try:
@@ -47,7 +55,10 @@ async def serve(config: AirflowConfig, static_tools: bool = False) -> None:
     add_airflow_prompts(mcp, mode="unsafe")
 
     try:
-        await mcp.run_async()
+        if transport in ["streamable-http", "sse"]:
+            await mcp.run_async(transport=transport, **transport_kwargs)
+        else:
+            await mcp.run_async()
     except Exception as e:
         logger.error("Server error: %s", e)
         await client.aclose()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -26,6 +26,17 @@ def test_main_help(runner):
     assert "--auth-token" in result.output
 
 
+def test_main_help_short(runner):
+    """Test main command help with -h shorthand."""
+    result = runner.invoke(main, ["-h"])
+    assert result.exit_code == 0
+    assert "MCP server for Airflow" in result.output
+    assert "--safe" in result.output
+    assert "--unsafe" in result.output
+    assert "--base-url" in result.output
+    assert "--auth-token" in result.output
+
+
 def test_main_missing_config(runner):
     """Test main with missing configuration."""
     result = runner.invoke(main, [])
@@ -126,3 +137,99 @@ def test_main_verbose_logging(runner):
                 call_args = mock_logging.call_args
                 # Just verify that stream parameter was passed (Click uses different stderr)
                 assert "stream" in call_args[1]
+
+
+def test_main_http_transport_flag(runner):
+    """Test main with --http flag."""
+    with patch("airflow_mcp_server.serve_unsafe") as mock_serve:
+        mock_serve.return_value = None
+        with patch("asyncio.run") as mock_asyncio:
+            result = runner.invoke(main, ["--http", "--port", "3000", "--host", "localhost", "--base-url", "http://localhost:8080", "--auth-token", "test-token"])
+
+            assert result.exit_code == 0
+            mock_asyncio.assert_called_once()
+
+            call_args = mock_serve.call_args
+            assert call_args[1]["transport"] == "streamable-http"
+            assert call_args[1]["port"] == 3000
+            assert call_args[1]["host"] == "localhost"
+
+
+def test_main_sse_transport_flag(runner):
+    """Test main with --sse flag."""
+    with patch("airflow_mcp_server.serve_unsafe") as mock_serve:
+        mock_serve.return_value = None
+        with patch("asyncio.run") as mock_asyncio:
+            result = runner.invoke(main, ["--sse", "--port", "3001", "--base-url", "http://localhost:8080", "--auth-token", "test-token"])
+
+            assert result.exit_code == 0
+            mock_asyncio.assert_called_once()
+
+            call_args = mock_serve.call_args
+            assert call_args[1]["transport"] == "sse"
+            assert call_args[1]["port"] == 3001
+            assert call_args[1]["host"] == "localhost"
+
+
+def test_main_http_sse_conflict(runner):
+    """Test main with conflicting --http and --sse flags."""
+    result = runner.invoke(main, ["--http", "--sse", "--base-url", "http://localhost:8080", "--auth-token", "test-token"])
+
+    assert result.exit_code == 2
+    assert "Cannot specify both --http and --sse" in result.output
+
+
+def test_main_sse_deprecation_warning(runner):
+    """Test that --sse flag shows deprecation warning."""
+    with patch("airflow_mcp_server.serve_unsafe") as mock_serve:
+        mock_serve.return_value = None
+        with patch("asyncio.run"):
+            result = runner.invoke(main, ["--sse", "--base-url", "http://localhost:8080", "--auth-token", "test-token"])
+
+            assert result.exit_code == 0
+            assert "Warning: SSE transport is deprecated" in result.output
+
+
+def test_main_safe_mode_with_http(runner):
+    """Test safe mode with HTTP transport."""
+    with patch("airflow_mcp_server.serve_safe") as mock_serve_safe:
+        mock_serve_safe.return_value = None
+        with patch("asyncio.run") as mock_asyncio:
+            result = runner.invoke(main, ["--safe", "--http", "--port", "4000", "--base-url", "http://localhost:8080", "--auth-token", "test-token"])
+
+            assert result.exit_code == 0
+            mock_asyncio.assert_called_once()
+
+            call_args = mock_serve_safe.call_args
+            assert call_args[1]["transport"] == "streamable-http"
+            assert call_args[1]["port"] == 4000
+
+
+def test_main_default_transport(runner):
+    """Test main with default stdio transport."""
+    with patch("airflow_mcp_server.serve_unsafe") as mock_serve:
+        mock_serve.return_value = None
+        with patch("asyncio.run") as mock_asyncio:
+            result = runner.invoke(main, ["--base-url", "http://localhost:8080", "--auth-token", "test-token"])
+
+            assert result.exit_code == 0
+            mock_asyncio.assert_called_once()
+
+            call_args = mock_serve.call_args
+            assert call_args[1]["transport"] == "stdio"
+            assert "port" not in call_args[1]
+            assert "host" not in call_args[1]
+
+
+def test_main_custom_host_port(runner):
+    """Test main with custom host and port."""
+    with patch("airflow_mcp_server.serve_unsafe") as mock_serve:
+        mock_serve.return_value = None
+        with patch("asyncio.run"):
+            result = runner.invoke(main, ["--http", "--port", "8000", "--host", "0.0.0.0", "--base-url", "http://localhost:8080", "--auth-token", "test-token"])
+
+            assert result.exit_code == 0
+
+            call_args = mock_serve.call_args
+            assert call_args[1]["port"] == 8000
+            assert call_args[1]["host"] == "0.0.0.0"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -28,7 +28,6 @@ async def test_safe_server_initialization(mock_config, mock_openapi_response):
         mock_client = AsyncMock()
         mock_client_class.return_value = mock_client
 
-        # Mock the HTTP response
         mock_response = Mock()
         mock_response.raise_for_status = Mock()
         mock_response.json.return_value = mock_openapi_response
@@ -71,7 +70,6 @@ async def test_unsafe_server_initialization(mock_config, mock_openapi_response):
         mock_client = AsyncMock()
         mock_client_class.return_value = mock_client
 
-        # Mock the HTTP response
         mock_response = Mock()
         mock_response.raise_for_status = Mock()
         mock_response.json.return_value = mock_openapi_response
@@ -144,3 +142,175 @@ async def test_server_run_error(mock_config, mock_openapi_response):
 
                         # Verify client was closed on error
                         mock_client.aclose.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_safe_server_http_transport(mock_config, mock_openapi_response):
+    """Test safe server with HTTP transport."""
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client_class.return_value = mock_client
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = mock_openapi_response
+        mock_client.get.return_value = mock_response
+
+        with patch("airflow_mcp_server.server_safe.FastMCP") as mock_fastmcp:
+            with patch("airflow_mcp_server.server_safe.HierarchicalToolManager"):
+                with patch("airflow_mcp_server.server_safe.add_airflow_resources"):
+                    with patch("airflow_mcp_server.server_safe.add_airflow_prompts"):
+                        mock_mcp_instance = Mock()
+                        mock_fastmcp.return_value = mock_mcp_instance
+                        mock_mcp_instance.run_async = AsyncMock()
+
+                        await server_safe.serve(mock_config, transport="streamable-http", port=3000, host="localhost")
+
+                        mock_mcp_instance.run_async.assert_called_once_with(transport="streamable-http", port=3000, host="localhost")
+
+
+@pytest.mark.asyncio
+async def test_safe_server_sse_transport(mock_config, mock_openapi_response):
+    """Test safe server with SSE transport."""
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client_class.return_value = mock_client
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = mock_openapi_response
+        mock_client.get.return_value = mock_response
+
+        with patch("airflow_mcp_server.server_safe.FastMCP") as mock_fastmcp:
+            with patch("airflow_mcp_server.server_safe.HierarchicalToolManager"):
+                with patch("airflow_mcp_server.server_safe.add_airflow_resources"):
+                    with patch("airflow_mcp_server.server_safe.add_airflow_prompts"):
+                        mock_mcp_instance = Mock()
+                        mock_fastmcp.return_value = mock_mcp_instance
+                        mock_mcp_instance.run_async = AsyncMock()
+
+                        await server_safe.serve(mock_config, transport="sse", port=3001, host="0.0.0.0")
+
+                        mock_mcp_instance.run_async.assert_called_once_with(transport="sse", port=3001, host="0.0.0.0")
+
+
+@pytest.mark.asyncio
+async def test_safe_server_stdio_transport(mock_config, mock_openapi_response):
+    """Test safe server with default stdio transport."""
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client_class.return_value = mock_client
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = mock_openapi_response
+        mock_client.get.return_value = mock_response
+
+        with patch("airflow_mcp_server.server_safe.FastMCP") as mock_fastmcp:
+            with patch("airflow_mcp_server.server_safe.HierarchicalToolManager"):
+                with patch("airflow_mcp_server.server_safe.add_airflow_resources"):
+                    with patch("airflow_mcp_server.server_safe.add_airflow_prompts"):
+                        mock_mcp_instance = Mock()
+                        mock_fastmcp.return_value = mock_mcp_instance
+                        mock_mcp_instance.run_async = AsyncMock()
+
+                        await server_safe.serve(mock_config, transport="stdio")
+
+                        mock_mcp_instance.run_async.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_unsafe_server_http_transport(mock_config, mock_openapi_response):
+    """Test unsafe server with HTTP transport."""
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client_class.return_value = mock_client
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = mock_openapi_response
+        mock_client.get.return_value = mock_response
+
+        with patch("airflow_mcp_server.server_unsafe.FastMCP") as mock_fastmcp:
+            with patch("airflow_mcp_server.server_unsafe.HierarchicalToolManager"):
+                with patch("airflow_mcp_server.server_unsafe.add_airflow_resources"):
+                    with patch("airflow_mcp_server.server_unsafe.add_airflow_prompts"):
+                        mock_mcp_instance = Mock()
+                        mock_fastmcp.return_value = mock_mcp_instance
+                        mock_mcp_instance.run_async = AsyncMock()
+
+                        await server_unsafe.serve(mock_config, transport="streamable-http", port=3000, host="localhost")
+
+                        mock_mcp_instance.run_async.assert_called_once_with(transport="streamable-http", port=3000, host="localhost")
+
+
+@pytest.mark.asyncio
+async def test_unsafe_server_sse_transport(mock_config, mock_openapi_response):
+    """Test unsafe server with SSE transport."""
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client_class.return_value = mock_client
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = mock_openapi_response
+        mock_client.get.return_value = mock_response
+
+        with patch("airflow_mcp_server.server_unsafe.FastMCP") as mock_fastmcp:
+            with patch("airflow_mcp_server.server_unsafe.HierarchicalToolManager"):
+                with patch("airflow_mcp_server.server_unsafe.add_airflow_resources"):
+                    with patch("airflow_mcp_server.server_unsafe.add_airflow_prompts"):
+                        mock_mcp_instance = Mock()
+                        mock_fastmcp.return_value = mock_mcp_instance
+                        mock_mcp_instance.run_async = AsyncMock()
+
+                        await server_unsafe.serve(mock_config, transport="sse", port=3001, host="0.0.0.0")
+
+                        mock_mcp_instance.run_async.assert_called_once_with(transport="sse", port=3001, host="0.0.0.0")
+
+
+@pytest.mark.asyncio
+async def test_server_config_validation():
+    """Test server config validation."""
+    config_no_url = AirflowConfig.__new__(AirflowConfig)
+    config_no_url.base_url = None
+    config_no_url.auth_token = "test-token"
+
+    with pytest.raises(ValueError, match="base_url is required"):
+        await server_safe.serve(config_no_url)
+
+    config_no_token = AirflowConfig.__new__(AirflowConfig)
+    config_no_token.base_url = "http://localhost:8080"
+    config_no_token.auth_token = None
+
+    with pytest.raises(ValueError, match="auth_token is required"):
+        await server_safe.serve(config_no_token)
+
+
+@pytest.mark.asyncio
+async def test_static_tools_mode_http_transport(mock_config, mock_openapi_response):
+    """Test static tools mode with HTTP transport."""
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client_class.return_value = mock_client
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = mock_openapi_response
+        mock_client.get.return_value = mock_response
+
+        with patch("airflow_mcp_server.server_safe.FastMCP") as mock_fastmcp:
+            with patch("airflow_mcp_server.server_safe.add_airflow_resources"):
+                with patch("airflow_mcp_server.server_safe.add_airflow_prompts"):
+                    mock_mcp_instance = Mock()
+                    mock_fastmcp.from_openapi.return_value = mock_mcp_instance
+                    mock_mcp_instance.run_async = AsyncMock()
+
+                    await server_safe.serve(mock_config, static_tools=True, transport="streamable-http", port=3000)
+
+                    mock_fastmcp.from_openapi.assert_called_once()
+                    call_args = mock_fastmcp.from_openapi.call_args
+                    assert call_args[1]["openapi_spec"] == mock_openapi_response
+                    assert call_args[1]["client"] == mock_client
+
+                    mock_mcp_instance.run_async.assert_called_once_with(transport="streamable-http", port=3000)


### PR DESCRIPTION
- Add --http and --sse CLI flags for transport selection
- Implement Streamable HTTP transport (recommended) and SSE transport (deprecated)
- Add --port and --host options for server configuration
- Update both safe and unsafe server modes to support new transports
- Add comprehensive test coverage for transport functionality
- Update README with transport options and usage examples
- Maintain full backward compatibility with stdio transport (default)
- Add config validation for required base_url and auth_token

Closes #23